### PR TITLE
spec_tiller:sync respects num_builds

### DIFF
--- a/lib/spec_tiller/build_matrix_parser.rb
+++ b/lib/spec_tiller/build_matrix_parser.rb
@@ -17,8 +17,8 @@ module BuildMatrixParser
     content_env_matrix = []
 
     env_matrix.each do |var_hash|
-      next if var_hash.empty? || var_hash["TEST_SUITE"].empty?
-      line = var_hash.map { |key, value| %Q(#{key}="#{value}") }.join(' ')
+      next if nil_or_empty?(var_hash)
+      line = var_hash.map { |key, value| %(#{key}="#{value}") }.join(' ')
 
       content_env_matrix << line
     end
@@ -27,4 +27,8 @@ module BuildMatrixParser
   end
   module_function :format_matrix
 
+  def self.nil_or_empty?(var_hash)
+    return true if var_hash.empty? || var_hash['TEST_SUITE'].nil?
+    var_hash['TEST_SUITE'].empty?
+  end
 end

--- a/lib/spec_tiller/sync_spec_file_list.rb
+++ b/lib/spec_tiller/sync_spec_file_list.rb
@@ -72,11 +72,12 @@ module SyncSpecFiles
       end
     end
 
-    def self.add_new_files(original, buckets, current_file_list, suggested_num_buckets)
+    def self.add_new_files(original, buckets, current_file_list, num_buckets)
       buckets_clone = buckets.map(&:dup)
-      current_num_buckets = buckets_clone.length
+      test_suite_worker_count = buckets_clone.length
 
-      num_buckets = current_num_buckets < suggested_num_buckets ? current_num_buckets : suggested_num_buckets
+      # This check is to determine if the stated bucket count is > available workers
+      num_buckets = test_suite_worker_count < num_buckets ? test_suite_worker_count : num_buckets
 
       added_files(original, current_file_list).each do |spec_file|
         bucket_index = rand(num_buckets)

--- a/spec/sync_spec_file_list_spec.rb
+++ b/spec/sync_spec_file_list_spec.rb
@@ -14,34 +14,71 @@ describe 'SyncSpecFiles' do
     end
     let(:travis_yaml) { YAML::load(File.open('spec/documents/.travis.yml')) }
 
-    before(:each) do
-      SyncSpecFiles.rewrite_travis_content(travis_yaml, current_file_list)
-    end
-
-    it 'adds new files to random line' do
-      expect(travis_yaml['env']['matrix'].join(' ')).to include('spec/test/new1.rb','spec/test2/new2.rb','spec/test/new3.rb')
-    end
-
-    it 'removes unused specs' do
-      travis_yaml['env']['matrix'].each do |bucket|
-        expect(bucket).not_to include('spec/features/three_vars.rb')
+    describe 'Static Yaml' do
+      before(:each) do
+        SyncSpecFiles.rewrite_travis_content(travis_yaml, current_file_list)
       end
 
-    end
+      it 'adds new files to random line' do
+        expect(travis_yaml['env']['matrix'].join(' ')).to include('spec/test/new1.rb','spec/test2/new2.rb','spec/test/new3.rb')
+      end
 
-    it 'removes lines without a TEST_SUITE' do
-      travis_yaml['env']['matrix'].each do |bucket|
-        expect(bucket).to include('TEST_SUITE="')
+      it 'removes unused specs' do
+        travis_yaml['env']['matrix'].each do |bucket|
+          expect(bucket).not_to include('spec/features/three_vars.rb')
+        end
+
+      end
+
+      it 'removes lines without a TEST_SUITE' do
+        travis_yaml['env']['matrix'].each do |bucket|
+          expect(bucket).to include('TEST_SUITE="')
+        end
+      end
+
+      it 'does not include ignored specs' do
+        travis_yaml['env']['matrix'].each do |bucket|
+          expect(bucket).not_to include('spec/features/ignore_me.rb')
+        end
       end
     end
 
-    it 'does not include ignored specs' do
-      travis_yaml['env']['matrix'].each do |bucket|
-        expect(bucket).not_to include('spec/features/ignore_me.rb')
+    describe 'Modified Yaml' do
+      describe 'Respects num_builds in syncing files' do
+        it 'when num_builds: 1, adds files to only the first two lines of the matrix' do
+          travis_yaml['num_builds'] = 1
+          SyncSpecFiles.rewrite_travis_content(travis_yaml, current_file_list) do |yaml|
+            matrix =  yaml['env']['matrix']
+            first_bucket = matrix.first
+            rest_buckets = matrix[1..-1].join(' ')
+
+            expect(first_bucket).to include('spec/test/new1.rb','spec/test2/new2.rb','spec/test/new3.rb')
+            expect(rest_buckets).not_to include('spec/test/new1.rb','spec/test2/new2.rb','spec/test/new3.rb')
+          end
+        end
+
+        it 'when num_builds: 2, adds files to only the first 2 lines of the matrix' do
+          travis_yaml['num_builds'] = 2
+          SyncSpecFiles.rewrite_travis_content(travis_yaml, current_file_list) do |yaml|
+          matrix = yaml['env']['matrix']
+          first_two_buckets = matrix[0..1].join(' ')
+          rest_buckets = matrix[2..-1].join(' ')
+
+          expect(first_two_buckets).to include('spec/test/new1.rb','spec/test2/new2.rb','spec/test/new3.rb')
+          expect(rest_buckets).not_to include('spec/test/new1.rb','spec/test2/new2.rb','spec/test/new3.rb')
+          end
+        end
+
+        it 'when num_builds > current bucket count it uses current bucket count' do
+          travis_yaml['num_builds'] = 100
+          SyncSpecFiles.rewrite_travis_content(travis_yaml, current_file_list) do |yaml|
+            matrix = yaml['env']['matrix']
+            buckets = matrix.join(' ')
+            expect(buckets).to include('spec/test/new1.rb','spec/test2/new2.rb','spec/test/new3.rb')
+          end
+        end
       end
-
     end
-
   end
 
 end


### PR DESCRIPTION
* Looks at num_builds in current travis yaml
* Only adds files to the first n lines of the matrix
* If num builds is greater than current matrix line numbers, it fallsback
  to previous behavior
* Preparation for having browser jobs run on different workers